### PR TITLE
Fix Ruby 2.0 compatibility of RedBook examples

### DIFF
--- a/examples/RedBook/font.rb
+++ b/examples/RedBook/font.rb
@@ -82,14 +82,14 @@ def makeRasterFont
 
   $fontOffset = glGenLists(128)
   i = 0
-  j = ?A
+  j = ?A.ord
   for i in 0...26
     glNewList($fontOffset + j, GL_COMPILE)
     glBitmap(8, 13, 0.0, 2.0, 10.0, 0.0, $letters[i].pack("C*"))
     glEndList()
     j+=1
   end
-  glNewList($fontOffset + ' '[0], GL_COMPILE)
+  glNewList($fontOffset + ' '.ord, GL_COMPILE)
   glBitmap(8, 13, 0.0, 2.0, 10.0, 0.0, $space.pack("C*"))
   glEndList()
 end

--- a/examples/RedBook/light.rb
+++ b/examples/RedBook/light.rb
@@ -5,6 +5,8 @@ require 'glu'
 require 'glut'
 require 'mathn'
 
+include Gl, Glu, Glut
+
 def init
   @fullscreen = false
   @xrot = 0

--- a/examples/RedBook/stroke.rb
+++ b/examples/RedBook/stroke.rb
@@ -107,12 +107,12 @@ def myinit
 
   base = glGenLists(128)
   glListBase(base)
-  glNewList(base+'A'[0], GL_COMPILE); drawLetter(Adata); glEndList()
-  glNewList(base+'E'[0], GL_COMPILE); drawLetter(Edata); glEndList()
-  glNewList(base+'P'[0], GL_COMPILE); drawLetter(Pdata); glEndList()
-  glNewList(base+'R'[0], GL_COMPILE); drawLetter(Rdata); glEndList()
-  glNewList(base+'S'[0], GL_COMPILE); drawLetter(Sdata); glEndList()
-  glNewList(base+' '[0], GL_COMPILE); glTranslate(8.0, 0.0, 0.0); glEndList()
+  glNewList(base+'A'.ord, GL_COMPILE); drawLetter(Adata); glEndList()
+  glNewList(base+'E'.ord, GL_COMPILE); drawLetter(Edata); glEndList()
+  glNewList(base+'P'.ord, GL_COMPILE); drawLetter(Pdata); glEndList()
+  glNewList(base+'R'.ord, GL_COMPILE); drawLetter(Rdata); glEndList()
+  glNewList(base+'S'.ord, GL_COMPILE); drawLetter(Sdata); glEndList()
+  glNewList(base+' '.ord, GL_COMPILE); glTranslate(8.0, 0.0, 0.0); glEndList()
 end
 
 $test1 = "A SPARE SERAPE APPEARS AS"


### PR DESCRIPTION
Three of the RedBook examples were failing to run with Ruby 2.0. The fixes are trivial, as per the attached commit.

```
$ ruby font.rb 
font.rb:87:in `+': String can't be coerced into Fixnum (TypeError)
    from font.rb:87:in `block in makeRasterFont'
    from font.rb:86:in `each'
    from font.rb:86:in `makeRasterFont'
    from font.rb:99:in `init'
    from font.rb:149:in `<main>'

$ ruby light.rb 
light.rb:146:in `<main>': undefined local variable or method `glutInit' for main:Object (NameError)

$ ruby stroke.rb 
stroke.rb:110:in `+': String can't be coerced into Fixnum (TypeError)
    from stroke.rb:110:in `myinit'
    from stroke.rb:165:in `<main>'
```
